### PR TITLE
Numbers cleanup

### DIFF
--- a/library/src/main/scala/org/podval/calendar/angles/Angle.scala
+++ b/library/src/main/scala/org/podval/calendar/angles/Angle.scala
@@ -1,31 +1,32 @@
 package org.podval.calendar.angles
 
 import org.podval.calendar.numbers.PeriodicNumber
+import Angles.Digit
 
 trait Angle[N <: Angle[N]] extends PeriodicNumber[Angles, N] { this: N =>
-  def degrees: Int = head
+  def degrees: Int = get(Digit.DEGREES)
 
-  def degrees(value: Int): N = head(value)
+  def degrees(value: Int): N = set(Digit.DEGREES, value)
 
-  def roundToDegrees: N = roundTo(0)
+  def roundToDegrees: N = roundTo(Digit.DEGREES)
 
-  def minutes: Int = tail(0)
+  def minutes: Int = get(Digit.MINUTES)
 
-  def minutes(value: Int): N = tail(0, value)
+  def minutes(value: Int): N = set(Digit.MINUTES, value)
 
-  def roundToMinutes: N = roundTo(1)
+  def roundToMinutes: N = roundTo(Digit.MINUTES)
 
-  def seconds: Int = tail(1)
+  def seconds: Int = get(Digit.SECONDS)
 
-  def seconds(value: Int): N = tail(1, value)
+  def seconds(value: Int): N = set(Digit.SECONDS, value)
 
-  def roundToSeconds: N = roundTo(2)
+  def roundToSeconds: N = roundTo(Digit.SECONDS)
 
-  def thirds: Int  = tail(2)
+  def thirds: Int  = get(Digit.THIRDS)
 
-  def thirds(value: Int): N = tail(2, value)
+  def thirds(value: Int): N = set(Digit.THIRDS, value)
 
-  def roundToThirds: N = roundTo(3)
+  def roundToThirds: N = roundTo(Digit.THIRDS)
 
   def toRadians: Double = math.toRadians(toDegrees)
 

--- a/library/src/main/scala/org/podval/calendar/angles/Angles.scala
+++ b/library/src/main/scala/org/podval/calendar/angles/Angles.scala
@@ -1,6 +1,6 @@
 package org.podval.calendar.angles
 
-import org.podval.calendar.numbers.{Digits, PeriodicVectorCompanion, NumbersMember,
+import org.podval.calendar.numbers.{Digits, DigitsDescriptor, PeriodicVectorCompanion, NumbersMember,
   PeriodicPointCompanion, PeriodicNumbers, PointCompanion, VectorCompanion}
 
 trait Angles extends PeriodicNumbers[Angles] {
@@ -32,30 +32,20 @@ trait Angles extends PeriodicNumbers[Angles] {
 
   final val Position = Point
 
+  object Digit extends DigitsDescriptor {
+    object DEGREES extends DigitBase("°")
+    object MINUTES extends DigitBase("′")
+    object SECONDS extends DigitBase("″")
+    object THIRDS  extends DigitBase("‴")
+
+    override val values: Seq[DigitsDescriptor.Digit] = Seq(DEGREES, MINUTES, SECONDS, THIRDS)
+  }
+
   final override def headRange: Int = 360
 
   final override def range(position: Int): Int = 60
 
-  final override def headSign: String = "°"
-
-  import Angles.PositionIndex
-
-  final override val signPartial: PartialFunction[Int, String] = {
-    case PositionIndex.MINUTES => "′"
-    case PositionIndex.SECONDS => "″"
-    case PositionIndex.THIRDS  => "‴"
-  }
-
-  final override val defaultLength: Int = PositionIndex.default
+  final override val defaultLength: Int = 3
 }
 
-
-object Angles extends Angles {
-  object PositionIndex {
-    final val MINUTES: Int = 0
-    final val SECONDS: Int = 1
-    final val THIRDS : Int = 2
-
-    final val default = 3
-  }
-}
+object Angles extends Angles

--- a/library/src/main/scala/org/podval/calendar/astronomy/SunLongitudeMean.scala
+++ b/library/src/main/scala/org/podval/calendar/astronomy/SunLongitudeMean.scala
@@ -1,5 +1,6 @@
 package org.podval.calendar.astronomy
 
+import org.podval.calendar.angles.Angles
 import org.podval.calendar.angles.Angles.Rotation
 import org.podval.calendar.jewish.{Jewish, Sun}
 import org.podval.calendar.numbers.BigRational
@@ -31,7 +32,7 @@ object SunLongitudeMean extends Days2Angle {
 
   // TODO move into tests
   def main(args: Array[String]) {
-    def m(n: Int) = (rambamValue * n).roundTo(2)
+    def m(n: Int) = (rambamValue * n).roundTo(Angles.Digit.SECONDS)
     for (n <- List(1, 10, 100, 1000, 10000, 354))
       println(n + " " + m(n))
 

--- a/library/src/main/scala/org/podval/calendar/dates/MomentBase.scala
+++ b/library/src/main/scala/org/podval/calendar/dates/MomentBase.scala
@@ -1,7 +1,7 @@
 package org.podval.calendar.dates
 
 import org.podval.calendar.times.TimePointBase
-import org.podval.judaica.metadata.LanguageString
+import org.podval.judaica.metadata.{LanguageSpec, LanguageString}
 
 trait MomentBase[C <: Calendar[C]] extends TimePointBase[C] with CalendarMember[C] with LanguageString
 { this: C#Moment =>
@@ -9,4 +9,18 @@ trait MomentBase[C <: Calendar[C]] extends TimePointBase[C] with CalendarMember[
   final def day: C#Day = calendar.Day(dayNumber)
 
   final def dayNumber: Int = days + 1
+
+  final override def toLanguageString(implicit spec: LanguageSpec): String =
+    day.toLanguageString +
+      " " + calendar.toString(time.hours) +
+      ":" + calendar.toString(time.minutes) +
+      "." + calendar.toString(time.partsWithoutMinutes) +
+      "." + calendar.toString(time.moments)
+
+  final def toSecondLanguageString(implicit spec: LanguageSpec): String =
+    day.toLanguageString +
+      " " + calendar.toString(time.hours) +
+      ":" + calendar.toString(time.minutes) +
+      ":" + calendar.toString(time.seconds) +
+      "." + calendar.toString(time.milliseconds)
 }

--- a/library/src/main/scala/org/podval/calendar/gregorian/GregorianMoment.scala
+++ b/library/src/main/scala/org/podval/calendar/gregorian/GregorianMoment.scala
@@ -1,18 +1,10 @@
 package org.podval.calendar.gregorian
 
 import org.podval.calendar.dates.MomentBase
-import org.podval.judaica.metadata.LanguageSpec
 import Gregorian.Moment
 
 trait GregorianMoment extends MomentBase[Gregorian] {
   final def morningHours(value: Int): Moment = firstHalfHours(value)
 
   final def afternoonHours(value: Int): Moment = secondHalfHours(value)
-
-  final override def toLanguageString(implicit spec: LanguageSpec): String =
-    day.toLanguageString +
-      " " + calendar.toString(time.hours) +
-      ":" + calendar.toString(time.minutes) +
-      ":" + calendar.toString(time.seconds) +
-      "." + calendar.toString(time.milliseconds)
 }

--- a/library/src/main/scala/org/podval/calendar/gregorian/GregorianYearCompanion.scala
+++ b/library/src/main/scala/org/podval/calendar/gregorian/GregorianYearCompanion.scala
@@ -4,6 +4,7 @@ import org.podval.calendar.dates.YearCompanion
 import Gregorian.{MonthNameAndLength, TimeVector, Year, YearCharacter}
 import Gregorian.Month.Name._
 import org.podval.calendar.numbers.BigRational
+import org.podval.calendar.times.Times
 
 abstract class GregorianYearCompanion extends YearCompanion[Gregorian] {
   protected final override def characters: Seq[YearCharacter] =
@@ -53,6 +54,7 @@ abstract class GregorianYearCompanion extends YearCompanion[Gregorian] {
     BigRational(365) +
     BigRational(1, 4) -
     BigRational(1, 100) +
-    BigRational(1, 400)
+    BigRational(1, 400),
+    length = Times.defaultLength
   )
 }

--- a/library/src/main/scala/org/podval/calendar/gregorian/GregorianYearCompanion.scala
+++ b/library/src/main/scala/org/podval/calendar/gregorian/GregorianYearCompanion.scala
@@ -55,6 +55,6 @@ abstract class GregorianYearCompanion extends YearCompanion[Gregorian] {
     BigRational(1, 4) -
     BigRational(1, 100) +
     BigRational(1, 400),
-    length = Times.defaultLength
+    length = numbers.defaultLength
   )
 }

--- a/library/src/main/scala/org/podval/calendar/jewish/JewishMoment.scala
+++ b/library/src/main/scala/org/podval/calendar/jewish/JewishMoment.scala
@@ -1,18 +1,10 @@
 package org.podval.calendar.jewish
 
 import org.podval.calendar.dates.MomentBase
-import org.podval.judaica.metadata.LanguageSpec
 import Jewish.Moment
 
 trait JewishMoment extends MomentBase[Jewish] {
   final def nightHours(value: Int): Moment = firstHalfHours(value)
 
   final def dayHours(value: Int): Moment = secondHalfHours(value)
-
-  final override def toLanguageString(implicit spec: LanguageSpec): String =
-    day.toLanguageString +
-      " " + calendar.toString(time.hours) +
-      ":" + calendar.toString(time.minutes) +
-      "." + calendar.toString(time.partsWithoutMinutes) +
-      "." + calendar.toString(time.moments)
 }

--- a/library/src/main/scala/org/podval/calendar/numbers/DigitsDescriptor.scala
+++ b/library/src/main/scala/org/podval/calendar/numbers/DigitsDescriptor.scala
@@ -1,0 +1,27 @@
+package org.podval.calendar.numbers
+
+import DigitsDescriptor.Digit
+
+trait DigitsDescriptor {
+  class DigitBase(override val sign: String) extends Digit {
+    final override def position: Int = values.indexOf(this)
+  }
+
+  val values: Seq[Digit]
+
+  def position(digit: Digit): Int = values.indexOf(digit)
+
+  def forPosition(index: Int): Digit = values(index)
+
+  final def length: Int = values.length
+}
+
+
+object DigitsDescriptor {
+
+  trait Digit {
+    def sign: String
+
+    def position: Int
+  }
+}

--- a/library/src/main/scala/org/podval/calendar/numbers/Number.scala
+++ b/library/src/main/scala/org/podval/calendar/numbers/Number.scala
@@ -1,5 +1,7 @@
 package org.podval.calendar.numbers
 
+import DigitsDescriptor.Digit
+
 trait Number[S <: Numbers[S], N <: Number[S, N]] extends Ordered[N] with NumbersMember[S] { this: N =>
   def digits: Seq[Int]
 
@@ -7,20 +9,16 @@ trait Number[S <: Numbers[S], N <: Number[S, N]] extends Ordered[N] with Numbers
 
   protected final def fromDigits(digits: Seq[Int]): N = companion.fromDigits(digits)
 
-  final def head: Int = get(0)
+  final def get(digit: Digit): Int = get(digit.position)
 
-  final def head(value: Int): N = set(0, value)
-
-  final def tail(position: Int): Int = get(position+1)
-
-  final def tail(position: Int, value: Int): N = set(position+1, value)
-
-  private final def get(position: Int): Int = {
+  final def get(position: Int): Int = {
     val normalDigits: Seq[Int] = normal.digits
     if (normalDigits.length > position) normalDigits(position) else 0
   }
 
-  private final def set(position: Int, value: Int): N = {
+  final def set(digit: Digit, value: Int): N = set(digit.position, value)
+
+  final def set(position: Int, value: Int): N = {
     val normalDigits: Seq[Int] = normal.digits
     val newDigits: Seq[Int] = normalDigits.padTo(position+1, 0).updated(position, value)
     fromDigits(newDigits)
@@ -55,6 +53,8 @@ trait Number[S <: Numbers[S], N <: Number[S, N]] extends Ordered[N] with Numbers
   final def unary_- : N = fromDigits(digits.map(-_))
 
   final def -(that: N): S#Vector = numbers.Vector.fromDigits(subtract(that))
+
+  final def roundTo(digit: Digit): N = roundTo(digit.position)
 
   final def roundTo(length: Int): N = {
     require(length >= 0)

--- a/library/src/main/scala/org/podval/calendar/numbers/NumberCompanion.scala
+++ b/library/src/main/scala/org/podval/calendar/numbers/NumberCompanion.scala
@@ -29,10 +29,10 @@ trait NumberCompanion[S <: Numbers[S], N <: Number[S, N]] extends NumbersMember[
 
   protected def negativeHead(value: Int): Int
 
-  final def from[T: Convertible](value: T, length: Int = numbers.defaultLength): N =
+  final def from[T: Convertible](value: T, length: Int): N =
     fromDigits(numbers.from[T](value, length))
 
-  final def fromRational(value: BigRational, length: Int = numbers.defaultLength): N = from[BigRational](value, length)
+  final def fromRational(value: BigRational, length: Int): N = from[BigRational](value, length)
 
-  final def fromDouble(value: Double, length: Int = numbers.defaultLength): N = from[Double](value, length)
+  final def fromDouble(value: Double, length: Int): N = from[Double](value, length)
 }

--- a/library/src/main/scala/org/podval/calendar/times/Time.scala
+++ b/library/src/main/scala/org/podval/calendar/times/Time.scala
@@ -4,17 +4,19 @@ import org.podval.calendar.numbers.NonPeriodicNumber
 import Times.{hoursPerHalfDay, partsPerHalfHour, partsPerMinute}
 
 trait Time[S <: Times[S], N <: Time[S, N]] extends NonPeriodicNumber[S, N] { this: N =>
-  final def days: Int = head
+  private def Digit = numbers.Digit
 
-  final def days(value: Int): N = head(value)
+  final def days: Int = get(Digit.DAYS)
+
+  final def days(value: Int): N = set(Digit.DAYS, value)
 
   final def day(number: Int): N = days(number-1)
 
   final def time: S#Vector = this - companion(days)
 
-  final def hours: Int = tail(0)
+  final def hours: Int = get(Digit.HOURS)
 
-  final def hours(value: Int): N = tail(0, value)
+  final def hours(value: Int): N = set(Digit.HOURS, value)
 
   final def firstHalfHours(value: Int): N = {
     require(0 <= hours && hours < hoursPerHalfDay)
@@ -26,9 +28,9 @@ trait Time[S <: Times[S], N <: Time[S, N]] extends NonPeriodicNumber[S, N] { thi
     hours(value + hoursPerHalfDay)
   }
 
-  final def parts: Int = tail(1)
+  final def parts: Int = get(Digit.PARTS)
 
-  final def parts(value: Int): N = tail(1, value)
+  final def parts(value: Int): N = set(Digit.PARTS, value)
 
   final def halfHour: N = parts(partsPerHalfHour)
 
@@ -53,7 +55,7 @@ trait Time[S <: Times[S], N <: Time[S, N]] extends NonPeriodicNumber[S, N] { thi
     partsWithoutMinutes(newParts).moments(newMoments)
   }
 
-  final def moments: Int = tail(2)
+  final def moments: Int = get(Digit.MOMENTS)
 
-  final def moments(value: Int): N = tail(2, value)
+  final def moments(value: Int): N = set(Digit.MOMENTS, value)
 }

--- a/library/src/main/scala/org/podval/calendar/times/Times.scala
+++ b/library/src/main/scala/org/podval/calendar/times/Times.scala
@@ -1,11 +1,20 @@
 package org.podval.calendar.times
 
-import org.podval.calendar.numbers.NonPeriodicNumbers
+import org.podval.calendar.numbers.{DigitsDescriptor, NonPeriodicNumbers}
 
 trait Times[S <: Times[S]] extends NonPeriodicNumbers[S] { this: S =>
-  type Point <: TimePointBase[S]
+  override type Point <: TimePointBase[S]
 
-  type Vector <: TimeVectorBase[S]
+  override type Vector <: TimeVectorBase[S]
+
+  final object Digit extends DigitsDescriptor {
+    object DAYS extends DigitBase("d")
+    object HOURS extends DigitBase("h")
+    object PARTS extends DigitBase("p")
+    object MOMENTS extends DigitBase("m")
+
+    override val values: Seq[DigitsDescriptor.Digit] = Seq(DAYS, HOURS, PARTS, MOMENTS)
+  }
 
   final override def range(position: Int): Int = position match {
     case 0 => Times.hoursPerDay
@@ -13,19 +22,10 @@ trait Times[S <: Times[S]] extends NonPeriodicNumbers[S] { this: S =>
     case 2 => Times.momentsPerPart
   }
 
-  final override def headSign: String = "d"
-
-  final override val signPartial: PartialFunction[Int, String] = {
-    case 0 => "h"
-    case 1 => "p"
-    case 2 => "m"
-  }
-
-  final override val defaultLength: Int = Times.defaultLength
+  final override val defaultLength: Int = 3
 
   val week: S#Vector = Vector().days(7)
 }
-
 
 object Times {
   final val hoursPerDay: Int = 24
@@ -51,6 +51,4 @@ object Times {
   final val millisecondsPerSecond: Int = 1000
 
   final val millisecondsPerMinute: Int = secondsPerMinute*millisecondsPerSecond
-
-  val defaultLength: Int = 3
 }

--- a/library/src/main/scala/org/podval/calendar/times/Times.scala
+++ b/library/src/main/scala/org/podval/calendar/times/Times.scala
@@ -21,7 +21,7 @@ trait Times[S <: Times[S]] extends NonPeriodicNumbers[S] { this: S =>
     case 2 => "m"
   }
 
-  final override val defaultLength: Int = 3
+  final override val defaultLength: Int = Times.defaultLength
 
   val week: S#Vector = Vector().days(7)
 }
@@ -51,4 +51,6 @@ object Times {
   final val millisecondsPerSecond: Int = 1000
 
   final val millisecondsPerMinute: Int = secondsPerMinute*millisecondsPerSecond
+
+  val defaultLength: Int = 3
 }

--- a/library/src/test/scala/org/podval/calendar/astronomy/TextTest.scala
+++ b/library/src/test/scala/org/podval/calendar/astronomy/TextTest.scala
@@ -1,6 +1,6 @@
 package org.podval.calendar.astronomy
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FunSpec, Matchers}
 import org.podval.calendar.angles.Angles
 import Angles.{Position, Rotation, headRange, range}
 import org.podval.calendar.jewish.{Jewish, LeapYearsCycle}
@@ -8,145 +8,183 @@ import Jewish.{Day, Month, Year}
 import org.podval.calendar.dates.YearsCycle
 import org.podval.calendar.numbers.BigRational
 
-class TextTest extends FlatSpec with Matchers {
-  "angle units" should "be as in KH 11:7" in {
-    headRange shouldBe 360
-    range(0) shouldBe 60
-    range(1) shouldBe 60
-    range(2) shouldBe 60
-    range(3) shouldBe 60
-    range(4) shouldBe 60
-    range(5) shouldBe 60
-    range(6) shouldBe 60
-  }
-
-  "zodiac" should "be as in KH 11:7-9" in {
-    Zodiac.values.length shouldBe 12
-    Zodiac.Aries.start shouldBe Position(0)
-    Zodiac.values.init.zip(Zodiac.values.tail).foreach {
-      case (prev: Zodiac, next: Zodiac) =>
-        (prev.start + Rotation(30)) shouldBe prev.end
-        next.start shouldBe prev.end
+class TextTest extends FunSpec with Matchers {
+  describe("Chapter 11") {
+    describe("Law 7") {
+      it("angle units") {
+        headRange shouldBe 360
+        range(0) shouldBe 60
+        range(1) shouldBe 60
+        range(2) shouldBe 60
+        range(3) shouldBe 60
+        range(4) shouldBe 60
+        range(5) shouldBe 60
+        range(6) shouldBe 60
+      }
     }
 
-    Zodiac.Gemini  .at(Rotation(10, 30, 40)) shouldBe Position(70, 30, 40)
-    Zodiac.Aquarius.at(Rotation(20        )) shouldBe Position(320)
+    describe("Laws 7-9") {
+      it("zodiac") {
+        Zodiac.values.length shouldBe 12
+        Zodiac.Aries.start shouldBe Position(0)
+        Zodiac.values.init.zip(Zodiac.values.tail).foreach {
+          case (prev: Zodiac, next: Zodiac) =>
+            (prev.start + Rotation(30)) shouldBe prev.end
+            next.start shouldBe prev.end
+        }
+
+        Zodiac.Gemini  .at(Rotation(10, 30, 40)) shouldBe Position(70, 30, 40)
+        Zodiac.Aquarius.at(Rotation(20        )) shouldBe Position(320)
+      }
+    }
+
+    describe("Law 12") {
+      it("angles subtraction") {
+        (Position(100, 20, 30) - Rotation(200, 50, 40)).canonical shouldBe Position(259, 29, 50)
+      }
+    }
+
+    describe("Law 16") {
+      it("epoch") {
+        LeapYearsCycle.inCycle(260, 17) shouldBe 4938
+        LeapYearsCycle.forNumber(4938) shouldBe YearsCycle.In(260, 17)
+        Epoch.Text.day shouldBe Year(4938).month(Month.Name.Nisan).day(3)
+        Epoch.Text.day.name shouldBe Day.Name.Chamishi
+      }
+    }
   }
 
-  "angles" should "subtract as in KH 11:12" in {
-    (Position(100, 20, 30) - Rotation(200, 50, 40)).canonical shouldBe Position(259, 29, 50)
+  describe("Chapter 12") {
+    describe("Law 2") {
+      it("mean Sun") {
+        val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Tammuz).day(14))
+        result.day.name shouldBe Day.Name.Shabbos
+        result.daysAfterEpoch shouldBe 100
+        result.sunLongitudeMean shouldBe Position(105, 37, 25)
+        result.sunLongitudeMean shouldBe Zodiac.Cancer.at(Rotation(15, 37, 25))
+      }
+    }
   }
 
-  "epoch" should "be as in KH 11:16" in {
-    LeapYearsCycle.inCycle(260, 17) shouldBe 4938
-    LeapYearsCycle.forNumber(4938) shouldBe YearsCycle.In(260, 17)
-    Epoch.Text.day shouldBe Year(4938).month(Month.Name.Nisan).day(3)
-    Epoch.Text.day.name shouldBe Day.Name.Chamishi
+  describe("Chapter 13") {
+    describe("Laws 9-10") {
+      it("true Sun") {
+        val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Tammuz).day(14))
+        result.day.name shouldBe Day.Name.Shabbos
+        result.sunLongitudeMean shouldBe Position(105, 37, 25)
+        result.sunApogee shouldBe Position(86, 45, 23)
+        result.sunCourseRaw shouldBe Rotation(18, 52, 2)
+        result.sunCourse shouldBe Rotation(19)
+        result.sunLongitudeCorrection shouldBe -Rotation(0, 38)
+        result.sunLongitudeTrueRaw shouldBe Position(104, 59, 25)
+      }
+    }
   }
 
-  "mean Sun calculations" should "be as in KH 12:2" in {
-    val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Tammuz).day(14))
-    result.day.name shouldBe Day.Name.Shabbos
-    result.daysAfterEpoch shouldBe 100
-    result.sunLongitudeMean shouldBe Position(105, 37, 25)
-    result.sunLongitudeMean shouldBe Zodiac.Cancer.at(Rotation(15, 37, 25))
+  describe("Chapter 15") {
+    describe("Laws 8-9") {
+      it("true Moon") {
+        val month: Month = Year(4938).month(Month.Name.Iyar)
+        val day: Day = month.day(2)
+        val newMoonDay: Day = month.newMoon.day
+        // TODO what is the day of sighting? Not the day of the new moon... assertResult(day)(newMoonDay)
+        val result = Calculator.Text.calculate(day)
+        result.day.name shouldBe Day.Name.Shishi
+        result.daysAfterEpoch shouldBe 29
+        result.sunLongitudeMean shouldBe Position(35, 38, 33)
+        result.moonLongitudeMeanAtTimeOfSighting shouldBe Position(53, 36, 39)
+        result.moonAnomalyMean shouldBe Position(103, 21, 46)
+        result.elongation shouldBe Rotation(17, 58, 6)
+        result.doubleElongation shouldBe Rotation(35, 56, 12)
+        result.moonLongitudeDoubleElongationCorrection shouldBe Rotation(5)
+        // TODO printing error in standard editions: 180.
+        // result.moonAnomalyTrue shouldBe Position(108, 21) // TODO got 108°21′46″
+        result.moonAnomalyTrue shouldBe Position(108)
+        // KH 15:9
+        result.moonAnomalyVisible shouldBe -Rotation(5, 1)
+        // TODO printing error in standard editions: 33.
+        result.moonLongitudeTrueRaw shouldBe Position(48, 35, 39)
+        result.moonLongitudeTrue shouldBe Zodiac.Taurus.at(Rotation(18, 36))
+      }
+    }
   }
 
-  "true Sun calculations" should "be as in KH 13:9-10" in {
-    val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Tammuz).day(14))
-    result.day.name shouldBe Day.Name.Shabbos
-    result.sunLongitudeMean shouldBe Position(105, 37, 25)
-    result.sunApogee shouldBe Position(86, 45, 23)
-    result.sunCourseRaw shouldBe Rotation(18, 52, 2)
-    result.sunCourse shouldBe Rotation(19)
-    result.sunLongitudeCorrection shouldBe -Rotation(0, 38)
-    result.sunLongitudeTrueRaw shouldBe Position(104, 59, 25)
+  describe("Chapter 16") {
+    describe("Laws 4-5") {
+      it("Moon head") {
+        val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Iyar).day(2))
+        result.day.name shouldBe Day.Name.Shishi
+        result.daysAfterEpoch shouldBe 29
+        // KH 16:5
+        result.moonHeadMeanReversed shouldBe Position(182, 29, 37)
+        result.moonHeadMeanRaw.canonical shouldBe Position(177, 30, 23)
+        result.moonHeadMean.canonical shouldBe Zodiac.Virgo.at(Rotation(27, 30))
+      }
+    }
+
+    describe("Law 12") {
+      it("latitude interpolation") {
+        Calculators.Text.moonLatitude(Rotation(53)) shouldBe Rotation(3, 59)
+      }
+    }
+
+    describe("Laws 16-18") {
+      it("latitude quadranting") {
+        Calculators.Text.moonLatitude(Rotation(150)) shouldBe Rotation(2, 30)
+        Calculators.Text.moonLatitude(Rotation(200)) shouldBe Rotation(1, 43)
+        Calculators.Text.moonLatitude(Rotation(300)) shouldBe Rotation(4, 20)
+      }
+    }
+
+    describe("Law 19") {
+      it("Moon lattitude") {
+        val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Iyar).day(2))
+        result.day.name shouldBe Day.Name.Shishi
+        result.moonLongitudeTrue shouldBe Zodiac.Taurus.at(Rotation(18, 36))
+        result.moonHeadMean.canonical shouldBe Zodiac.Virgo.at(Rotation(27, 30))
+        result.moonLatitudeCourseRaw shouldBe Rotation(231, 6)
+        result.moonLatitude shouldBe Rotation(3, 53)
+      }
+    }
   }
 
-  "true Moon calculations" should "be as in KH 15:8-9" in {
-    val month: Month = Year(4938).month(Month.Name.Iyar)
-    val day: Day = month.day(2)
-    val newMoonDay: Day = month.newMoon.day
-    // TODO what is the day of sighting? Not the day of the new moon... assertResult(day)(newMoonDay)
-    val result = Calculator.Text.calculate(day)
-    result.day.name shouldBe Day.Name.Shishi
-    result.daysAfterEpoch shouldBe 29
-    result.sunLongitudeMean shouldBe Position(35, 38, 33)
-    result.moonLongitudeMeanAtTimeOfSighting shouldBe Position(53, 36, 39)
-    result.moonAnomalyMean shouldBe Position(103, 21, 46)
-    result.elongation shouldBe Rotation(17, 58, 6)
-    result.doubleElongation shouldBe Rotation(35, 56, 12)
-    result.moonLongitudeDoubleElongationCorrection shouldBe Rotation(5)
-    // TODO printing error in standard editions: 180.
-    // result.moonAnomalyTrue shouldBe Position(108, 21) // TODO got 108°21′46″
-    result.moonAnomalyTrue shouldBe Position(108)
-    // KH 15:9
-    result.moonAnomalyVisible shouldBe -Rotation(5, 1)
-    // TODO printing error in standard editions: 33.
-    result.moonLongitudeTrueRaw shouldBe Position(48, 35, 39)
-    result.moonLongitudeTrue shouldBe Zodiac.Taurus.at(Rotation(18, 36))
-  }
+  describe("Chapter 17") {
+    describe("Laws 13-14") {
+      it("arc of sighting") {
+        val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Iyar).day(2))
+        result.day.name shouldBe Day.Name.Shishi
+        result.sunLongitudeTrue shouldBe Zodiac.Taurus.at(Rotation(7, 9))
+        result.moonLongitudeTrue shouldBe Zodiac.Taurus.at(Rotation(18, 36))
+        result.moonLatitude shouldBe Rotation(3, 53)
+        result.latitude1 shouldBe result.moonLatitude
+        result.isMoonLatitudeNortherly shouldBe false
+        result.longitude1 shouldBe Rotation(11, 27)
+        result.longitudeSightingAdjustment shouldBe Rotation(1)
+        result.longitude2 shouldBe Rotation(10, 27)
+        result.latitudeSightingAdjustment shouldBe Rotation(0, 10)
+        result.latitude2 shouldBe Rotation(4, 3)
+        result.moonCircuitPortion shouldBe BigRational(1, 4)
+        result.moonCircuit shouldBe Rotation(1, 1)
+        // KH 17:14
+        result.longitude3 shouldBe Rotation(11, 28)
+        // TODO "this longitude is in Taurus" - but longitude3 isn't, so I get 1/6 instead of 1/5...
+        // Am I supposed to look at moonTrueLongitude?!
+        result.moonLongitude3Portion shouldBe BigRational(1, 5)
+        result.moonLongitude3Correction shouldBe Rotation(2, 18)
+        result.longitude4 shouldBe Rotation(13, 46)
+        result.geographicCorrection shouldBe Rotation(2, 35)
+        result.arcOfSighting shouldBe Rotation(11, 11)
+      }
+    }
 
-  "moon head calculations" should "be as in KH 16:4-5" in {
-    val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Iyar).day(2))
-    result.day.name shouldBe Day.Name.Shishi
-    result.daysAfterEpoch shouldBe 29
-    // KH 16:5
-    result.moonHeadMeanReversed shouldBe Position(182, 29, 37)
-    result.moonHeadMeanRaw.canonical shouldBe Position(177, 30, 23)
-    result.moonHeadMean.canonical shouldBe Zodiac.Virgo.at(Rotation(27, 30))
-  }
-
-  "interpolation of the lattitude" should "be as in KH 16:12" in {
-    Calculators.Text.moonLatitude(Rotation(53)) shouldBe Rotation(3, 59)
-  }
-
-  "quadranting of the lattitude" should "be as in KH 16:16-18" in {
-    Calculators.Text.moonLatitude(Rotation(150)) shouldBe Rotation(2, 30)
-    Calculators.Text.moonLatitude(Rotation(200)) shouldBe Rotation(1, 43)
-    Calculators.Text.moonLatitude(Rotation(300)) shouldBe Rotation(4, 20)
-  }
-
-  "moon lattitude calculations" should "be as in KH 16:19" in {
-    val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Iyar).day(2))
-    result.day.name shouldBe Day.Name.Shishi
-    result.moonLongitudeTrue shouldBe Zodiac.Taurus.at(Rotation(18, 36))
-    result.moonHeadMean.canonical shouldBe Zodiac.Virgo .at(Rotation(27, 30))
-    result.moonLatitudeCourseRaw shouldBe Rotation(231, 6)
-    result.moonLatitude shouldBe Rotation(3, 53)
-  }
-
-  "arc of sighting calculations" should "be as in KH 17:13-14" in {
-    val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Iyar).day(2))
-    result.day.name shouldBe Day.Name.Shishi
-    result.sunLongitudeTrue shouldBe Zodiac.Taurus.at(Rotation(7, 9))
-    result.moonLongitudeTrue shouldBe Zodiac.Taurus.at(Rotation(18, 36))
-    result.moonLatitude shouldBe Rotation( 3, 53)
-    result.latitude1 shouldBe result.moonLatitude
-    result.isMoonLatitudeNortherly shouldBe false
-    result.longitude1 shouldBe Rotation(11, 27)
-    result.longitudeSightingAdjustment shouldBe Rotation(1)
-    result.longitude2 shouldBe Rotation(10, 27)
-    result.latitudeSightingAdjustment shouldBe Rotation( 0, 10)
-    result.latitude2 shouldBe Rotation( 4, 3)
-    result.moonCircuitPortion shouldBe BigRational(1, 4)
-    result.moonCircuit shouldBe Rotation( 1, 1)
-    // KH 17:14
-    result.longitude3 shouldBe Rotation(11, 28)
-    // TODO "this longitude is in Taurus" - but longitude3 isn't, so I get 1/6 instead of 1/5...
-    // Am I supposed to look at moonTrueLongitude?!
-    result.moonLongitude3Portion shouldBe BigRational(1, 5)
-    result.moonLongitude3Correction shouldBe Rotation( 2, 18)
-    result.longitude4 shouldBe Rotation(13, 46)
-    result.geographicCorrection shouldBe Rotation( 2, 35)
-    result.arcOfSighting shouldBe Rotation(11, 11)
-  }
-
-  "isSightable calculations" should "be as in KH 17:22" in {
-    val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Iyar).day(2))
-    result.day.name shouldBe Day.Name.Shishi
-    result.arcOfSighting shouldBe Rotation(11, 11)
-    result.longitude1 shouldBe Rotation(11, 27)
-    result.isMoonSightable shouldBe true
+    describe("Law 22") {
+      it("is sightable?") {
+        val result = Calculator.Text.calculate(Year(4938).month(Month.Name.Iyar).day(2))
+        result.day.name shouldBe Day.Name.Shishi
+        result.arcOfSighting shouldBe Rotation(11, 11)
+        result.longitude1 shouldBe Rotation(11, 27)
+        result.isMoonSightable shouldBe true
+      }
+    }
   }
 }

--- a/library/src/test/scala/org/podval/calendar/jewish/TextTest.scala
+++ b/library/src/test/scala/org/podval/calendar/jewish/TextTest.scala
@@ -1,6 +1,6 @@
 package org.podval.calendar.jewish
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FunSpec, Matchers}
 import org.podval.calendar.times.Times.{hoursPerDay, hoursPerHalfDay, momentsPerPart, partsPerHour}
 import Jewish.{Day, Month, TimeVector, Year, range, week}
 import LeapYearsCycle.{leapYear, normalYear}
@@ -9,192 +9,244 @@ import Sun.{RavAda, Shmuel}
 import org.podval.calendar.dates.YearsCycle
 
 /**
- * Tests based on the statements from the text itself.
- */
-class TextTest extends FlatSpec with Matchers {
-  "time units" should "be as in KH 6:2" in {
-    hoursPerDay shouldBe 24
-    range(0) shouldBe 24
-    hoursPerHalfDay shouldBe 12
-    partsPerHour shouldBe 1080
-    range(1) shouldBe 1080
-    partsPerHour % 2 shouldBe 0
-    partsPerHour % 4 shouldBe 0
-    partsPerHour % 8 shouldBe 0
-    partsPerHour % 3 shouldBe 0
-    partsPerHour % 6 shouldBe 0
-    partsPerHour % 9 shouldBe 0
-    partsPerHour % 10 shouldBe 0
-    momentsPerPart shouldBe 76
-    range(2) shouldBe 76
+  * Tests based on the statements from the text itself.
+  */
+class TextTest extends FunSpec with Matchers {
+  describe("Chapter 6") {
+    describe("Law 2: Time Units") {
+      it("hours") {
+        hoursPerDay shouldBe 24
+        range(0) shouldBe 24
+        hoursPerHalfDay shouldBe 12
+      }
+      it("parts") {
+        partsPerHour shouldBe 1080
+        range(1) shouldBe 1080
+        partsPerHour % 2 shouldBe 0
+        partsPerHour % 4 shouldBe 0
+        partsPerHour % 8 shouldBe 0
+        partsPerHour % 3 shouldBe 0
+        partsPerHour % 6 shouldBe 0
+        partsPerHour % 9 shouldBe 0
+        partsPerHour % 10 shouldBe 0
+      }
+      it("moments") {
+        momentsPerPart shouldBe 76
+        range(2) shouldBe 76
+      }
+    }
+
+    describe("Law 3") {
+      it("mean lunar period") {
+        meanLunarPeriod shouldBe TimeVector().days(29).hours(12).parts(793)
+      }
+    }
+
+    describe("Law 4") {
+      it("year lengths") {
+        normalYear shouldBe meanLunarPeriod*12
+        normalYear shouldBe TimeVector().days(354).hours( 8).parts(876)
+
+        leapYear shouldBe meanLunarPeriod*13
+        leapYear shouldBe TimeVector().days(383).hours(21).parts(589)
+
+        // see also KH 9:1, 10:6
+        Shmuel.yearLength shouldBe TimeVector().days(365).hours(6)
+        (Shmuel.yearLength - normalYear) shouldBe TimeVector().days(10).hours(21).parts(204)
+      }
+    }
+
+    describe("Law 5: Reminders for a Week") {
+      it("month") {
+        reminderForWeek(meanLunarPeriod) shouldBe TimeVector().days(1).hours(12).parts(793)
+      }
+      it("normal year") {
+        reminderForWeek(normalYear     ) shouldBe TimeVector().days(4).hours( 8).parts(876)
+      }
+      it("leap year") {
+        reminderForWeek(leapYear       ) shouldBe TimeVector().days(5).hours(21).parts(589)
+      }
+    }
+
+    describe("Law 7") {
+      it("molad Nisan example") {
+        (TimeVector().hours(17).parts(107) + meanLunarPeriod).time shouldBe
+          TimeVector().hours( 5).parts(900)
+      }
+    }
+
+    describe("Law 8: First New Moons") {
+      val year1newMoon = Year(1).newMoon
+
+      it("year 1") {
+        year1newMoon.day.name shouldBe Day.Name.Sheni
+        // see also KH 6:13
+        year1newMoon.time shouldBe TimeVector().hours(5).parts(204)
+      }
+
+      it("year 2") {
+        val year2newMoon = Year(2).newMoon
+        year2newMoon.day.name shouldBe Day.Name.Shishi
+        year2newMoon.time shouldBe TimeVector().hours(14)
+
+        (year2newMoon - meanLunarPeriod*12) shouldBe year1newMoon
+      }
+    }
+
+    describe("Law 10") {
+      it("year of Shmuel") {
+        // see also 9:1-2
+        LeapYearsCycle.yearsInCycle shouldBe 19
+        LeapYearsCycle.leapYearsInCycle shouldBe 7
+        Shmuel.yearLength shouldBe TimeVector().days(365).hours(6)
+        LeapYearsCycle.cycleLength shouldBe (normalYear*12 + leapYear*7)
+        (Shmuel.yearLength*LeapYearsCycle.yearsInCycle - LeapYearsCycle.cycleLength) shouldBe
+          TimeVector().hours(1).parts(485)
+        // KH 9:2
+        Shmuel.seasonLength shouldBe TimeVector().days(91).hours(7).halfHour
+      }
+    }
+
+    describe("Law 11") {
+      it("leap years") {
+        LeapYearsCycle.leapYears shouldBe Set(3, 6, 8, 11, 14, 17, 19)
+      }
+    }
+
+    describe("Law 12") {
+      it("cycle remainder") {
+        reminderForWeek(TimeVector().days(4).hours( 8).parts(876)*12 +
+          TimeVector().days(5).hours(21).parts(589)* 7) shouldBe
+          TimeVector().days(2).hours(16).parts(595)
+      }
+    }
   }
 
-  "mean lunar period" should "be as in KH 6:3" in {
-    meanLunarPeriod shouldBe TimeVector().days(29).hours(12).parts(793)
+  describe("Chapter 8") {
+    describe("Laws 7-8") {
+      it("year length for short years") {
+        Jewish.Year.shortNonLeapYearLength shouldBe 353
+        Jewish.Year.shortLeapYearLength shouldBe 383
+      }
+    }
+
+    describe("Law 9") {
+      it("kind of the year") {
+        var numberRegular: Int = 0
+        var numberFull: Int = 0
+        var numberShort: Int = 0
+        for (yearNumber <- 2 to 6000) {
+          val year: Year = Year(yearNumber)
+          if (!year.isLeap) {
+            val nextYearFirstDay: Day = year.next.firstDay
+            if (year.firstDay.is(Day.Name.Chamishi)) {
+              if (nextYearFirstDay.is(Day.Name.Sheni)) {
+                numberRegular += 1
+                year.kind shouldBe Year.Kind.Regular
+              }
+              if (nextYearFirstDay.is(Day.Name.Shlishi)) {
+                numberFull += 1
+                year.kind shouldBe Year.Kind.Full
+              }
+            }
+            if (year.firstDay.is(Day.Name.Shabbos)) {
+              if (nextYearFirstDay.is(Day.Name.Shlishi)) {
+                numberShort += 1
+                year.kind shouldBe Year.Kind.Short
+              }
+            }
+          }
+        }
+
+        // Verify that we saw some years with properties from the text
+        assert(numberRegular > 0) // 1084 of them!
+        assert(numberFull    > 0) // 198 of them!
+        assert(numberShort   > 0) // 259 of them!
+      }
+    }
+
+    describe("Law 10") {
+      it("year kind laws") {
+        import Day.Name._
+        for (yearNumber <- 1 to 6000) {
+          val year = Year(yearNumber)
+          val roshHashono = year.firstDay
+          roshHashono.name match {
+            case Shlishi  => assert(Year.Kind.Regular == year.kind)
+            case Shabbos  => assert(Year.Kind.Regular != year.kind)
+            case Sheni    => assert(Year.Kind.Regular != year.kind)
+            case Chamishi =>
+              if (year.isLeap) assert(Year.Kind.Regular != year.kind)
+              else assert(Year.Kind.Short != year.kind)
+            case _ => throw new IllegalArgumentException
+          }
+        }
+      }
+    }
   }
 
-  "year lengths" should "be as in KH 6:4" in {
-    normalYear shouldBe meanLunarPeriod*12
-    normalYear shouldBe TimeVector().days(354).hours( 8).parts(876)
+  describe("Chapter 9") {
+    describe("Laws 3-4") {
+      it("first tkufas Nisan for Shmuel") {
+        Moon.firstMoladNisan shouldBe Year(1).month(Month.Name.Nisan).newMoon
+        (Moon.firstMoladNisan - Shmuel.firstTkufasNisan) shouldBe
+          TimeVector().days(7).hours(9).parts(642)
+        Shmuel.firstTkufasNisan.day.name shouldBe Day.Name.Rvii
+      }
+    }
 
-    leapYear shouldBe meanLunarPeriod*13
-    leapYear shouldBe TimeVector().days(383).hours(21).parts(589)
+    describe("Laws 5-7") {
+      it("tkufos of 4930") {
+        val year: Year = Year(4930)
 
-    // (see also KH 9:1, 10:6)
-    Shmuel.yearLength shouldBe TimeVector().days(365).hours(6)
-    (Shmuel.yearLength - normalYear) shouldBe TimeVector().days(10).hours(21).parts(204)
+        LeapYearsCycle.forYear(year) shouldBe YearsCycle.In(260, 9)
+
+        val tkufasNisan = Shmuel.seasonForYear(Season.TkufasNisan, year)
+        tkufasNisan.day.name shouldBe Day.Name.Chamishi
+        tkufasNisan.time shouldBe TimeVector().hours(6)
+        tkufasNisan.day shouldBe year.month(Month.Name.Nisan).day(8)
+
+        val tkufasTammuz = Shmuel.seasonForYear(Season.TkufasTammuz, year)
+        tkufasTammuz.day.name shouldBe Day.Name.Chamishi
+        tkufasTammuz.time shouldBe TimeVector().hours(13).halfHour
+
+        val tkufasTishrei = Shmuel.seasonForYear(Season.TkufasTishrei, year)
+        tkufasTishrei.day.name shouldBe Day.Name.Chamishi
+        tkufasTishrei.time shouldBe TimeVector().hours(21)
+
+        val tkufasTeves = Shmuel.seasonForYear(Season.TkufasTeves, year)
+        tkufasTeves.day.name shouldBe Day.Name.Shishi
+        tkufasTeves.time shouldBe TimeVector().hours(4).halfHour
+
+        val nextTkufasNisan = Shmuel.seasonForYear(Season.TkufasNisan, year+1)
+        nextTkufasNisan.day.name shouldBe Day.Name.Shishi
+        nextTkufasNisan.time shouldBe TimeVector().hours(12)
+      }
+    }
   }
 
-  "weekly reminders of month and year" should "be as in KH 6:5" in {
-    reminderForWeek(meanLunarPeriod) shouldBe TimeVector().days(1).hours(12).parts(793)
-    reminderForWeek(normalYear     ) shouldBe TimeVector().days(4).hours( 8).parts(876)
-    reminderForWeek(leapYear       ) shouldBe TimeVector().days(5).hours(21).parts(589)
-  }
+  describe("Chapter 10") {
+    describe("Laws 1-2") {
+      it("year of RavAda") {
+        RavAda.yearLength shouldBe TimeVector().days(365).hours(5 ).parts(997).moments(48)
+        (RavAda.yearLength - normalYear) shouldBe
+          TimeVector().days( 10).hours(21).parts(121).moments(48)
+        (RavAda.yearLength*LeapYearsCycle.yearsInCycle - LeapYearsCycle.cycleLength) shouldBe TimeVector.zero
+        // KH 10:2
+        RavAda.seasonLength shouldBe
+          TimeVector().days(91).hours(7).parts(519).moments(31)
+      }
+    }
 
-  "molad Nisan example from KH 6:7" should "be correct" in {
-    (TimeVector().hours(17).parts(107) + meanLunarPeriod).time shouldBe
-     TimeVector().hours( 5).parts(900)
-  }
-
-  "first two years' new moons" should "be as in KH 6:8" in {
-    val year1newMoon = Year(1).newMoon
-    year1newMoon.day.name shouldBe Day.Name.Sheni
-    // see also KH 6:13
-    year1newMoon.time shouldBe TimeVector().hours(5).parts(204)
-
-    val year2newMoon = Year(2).newMoon
-    year2newMoon.day.name shouldBe Day.Name.Shishi
-    year2newMoon.time shouldBe TimeVector().hours(14)
-
-    (year2newMoon - meanLunarPeriod*12) shouldBe year1newMoon
-  }
-
-  "year of Shmuel" should "be as in KH 6:10; 9:1-2" in {
-    LeapYearsCycle.yearsInCycle shouldBe 19
-    LeapYearsCycle.leapYearsInCycle shouldBe 7
-    Shmuel.yearLength shouldBe TimeVector().days(365).hours(6)
-    LeapYearsCycle.cycleLength shouldBe (normalYear*12 + leapYear*7)
-    (Shmuel.yearLength*LeapYearsCycle.yearsInCycle - LeapYearsCycle.cycleLength) shouldBe
-      TimeVector().hours(1).parts(485)
-    // KH 9:2
-    Shmuel.seasonLength shouldBe TimeVector().days(91).hours(7).halfHour
-  }
-
-  "leap years" should "be as in KH 6:11" in {
-    LeapYearsCycle.leapYears shouldBe Set(3, 6, 8, 11, 14, 17, 19)
-  }
-
-  "cycle remainder" should "be as in KH 6:12" in {
-    reminderForWeek(TimeVector().days(4).hours( 8).parts(876)*12 +
-     TimeVector().days(5).hours(21).parts(589)* 7) shouldBe
-     TimeVector().days(2).hours(16).parts(595)
+    describe("Law 3") {
+      it("first tkufas Nisan for RavAda") {
+        (Moon.firstMoladNisan - RavAda.firstTkufasNisan) shouldBe
+          TimeVector().hours(9).parts(642)
+        RavAda.firstTkufasNisan.day.name shouldBe Day.Name.Rvii
+      }
+    }
   }
 
   private def reminderForWeek(ofWhat: TimeVector): TimeVector =
     ofWhat - (week * (ofWhat.toRational / week.toRational).whole)
-
-  "year length for short years" should "be as in KH 8:7-8" in {
-    Jewish.Year.shortNonLeapYearLength shouldBe 353
-    Jewish.Year.shortLeapYearLength shouldBe 383
-  }
-
-  "kind of the year" should "be correct for years from KH 8:9" in {
-    var numberRegular: Int = 0
-    var numberFull: Int = 0
-    var numberShort: Int = 0
-    for (yearNumber <- 2 to 6000) {
-      val year: Year = Year(yearNumber)
-      if (!year.isLeap) {
-        val nextYearFirstDay: Day = year.next.firstDay
-        if (year.firstDay.is(Day.Name.Chamishi)) {
-          if (nextYearFirstDay.is(Day.Name.Sheni)) {
-            numberRegular += 1
-            year.kind shouldBe Year.Kind.Regular
-          }
-          if (nextYearFirstDay.is(Day.Name.Shlishi)) {
-            numberFull += 1
-            year.kind shouldBe Year.Kind.Full
-          }
-        }
-        if (year.firstDay.is(Day.Name.Shabbos)) {
-          if (nextYearFirstDay.is(Day.Name.Shlishi)) {
-            numberShort += 1
-            year.kind shouldBe Year.Kind.Short
-          }
-        }
-      }
-    }
-
-    // Verify that we saw some years with properties from the text
-    assert(numberRegular > 0) // 1084 of them!
-    assert(numberFull    > 0) // 198 of them!
-    assert(numberShort   > 0) // 259 of them!
-  }
-
-  "year kind laws" should "be as in KH 8:10" in {
-    import Day.Name._
-    for (yearNumber <- 1 to 6000) {
-      val year = Year(yearNumber)
-      val roshHashono = year.firstDay
-      roshHashono.name match {
-        case Shlishi  => assert(Year.Kind.Regular == year.kind)
-        case Shabbos  => assert(Year.Kind.Regular != year.kind)
-        case Sheni    => assert(Year.Kind.Regular != year.kind)
-        case Chamishi =>
-          if (year.isLeap) assert(Year.Kind.Regular != year.kind)
-          else assert(Year.Kind.Short != year.kind)
-        case _ => throw new IllegalArgumentException
-      }
-    }
-  }
-
-  "first tkufas Nisan for Shmuel" should "be as in KH 9:3-4" in {
-    Moon.firstMoladNisan shouldBe Year(1).month(Month.Name.Nisan).newMoon
-    (Moon.firstMoladNisan - Shmuel.firstTkufasNisan) shouldBe
-      TimeVector().days(7).hours(9).parts(642)
-    Shmuel.firstTkufasNisan.day.name shouldBe Day.Name.Rvii
-  }
-
-  "tkufos of 4930" should "be as in KH 9:5-7" in {
-    val year: Year = Year(4930)
-
-    LeapYearsCycle.forYear(year) shouldBe YearsCycle.In(260, 9)
-
-    val tkufasNisan = Shmuel.seasonForYear(Season.TkufasNisan, year)
-    tkufasNisan.day.name shouldBe Day.Name.Chamishi
-    tkufasNisan.time shouldBe TimeVector().hours(6)
-    tkufasNisan.day shouldBe year.month(Month.Name.Nisan).day(8)
-
-    val tkufasTammuz = Shmuel.seasonForYear(Season.TkufasTammuz, year)
-    tkufasTammuz.day.name shouldBe Day.Name.Chamishi
-    tkufasTammuz.time shouldBe TimeVector().hours(13).halfHour
-
-    val tkufasTishrei = Shmuel.seasonForYear(Season.TkufasTishrei, year)
-    tkufasTishrei.day.name shouldBe Day.Name.Chamishi
-    tkufasTishrei.time shouldBe TimeVector().hours(21)
-
-    val tkufasTeves = Shmuel.seasonForYear(Season.TkufasTeves, year)
-    tkufasTeves.day.name shouldBe Day.Name.Shishi
-    tkufasTeves.time shouldBe TimeVector().hours(4).halfHour
-
-    val nextTkufasNisan = Shmuel.seasonForYear(Season.TkufasNisan, year+1)
-    nextTkufasNisan.day.name shouldBe Day.Name.Shishi
-    nextTkufasNisan.time shouldBe TimeVector().hours(12)
-  }
-
-  "year of RavAda" should "be as in KH 10:1-2" in {
-    RavAda.yearLength shouldBe TimeVector().days(365).hours(5 ).parts(997).moments(48)
-    (RavAda.yearLength - normalYear) shouldBe
-      TimeVector().days( 10).hours(21).parts(121).moments(48)
-    (RavAda.yearLength*LeapYearsCycle.yearsInCycle - LeapYearsCycle.cycleLength) shouldBe TimeVector.zero
-    // KH 10:2
-    RavAda.seasonLength shouldBe
-      TimeVector().days(91).hours(7).parts(519).moments(31)
-  }
-
-  "first tkufas Nisan for RavAda" should "as in KH 10:3" in {
-    (Moon.firstMoladNisan - RavAda.firstTkufasNisan) shouldBe
-      TimeVector().hours(9).parts(642)
-    RavAda.firstTkufasNisan.day.name shouldBe Day.Name.Rvii
-  }
 }

--- a/library/src/test/scala/org/podval/calendar/times/SimpleTimesTest.scala
+++ b/library/src/test/scala/org/podval/calendar/times/SimpleTimesTest.scala
@@ -98,7 +98,7 @@ final class SimpleTimesTest extends FlatSpec with GeneratorDrivenPropertyChecks 
   "fromRational()" should "be correct" in {
     def test(value: Vector): Unit = {
       val rational = value.toRational
-      val number = Vector.fromRational(rational)
+      val number = Vector.fromRational(rational, Times.defaultLength)
       number shouldBe value
     }
 

--- a/library/src/test/scala/org/podval/calendar/times/SimpleTimesTest.scala
+++ b/library/src/test/scala/org/podval/calendar/times/SimpleTimesTest.scala
@@ -4,6 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.podval.calendar.numbers.BigRational
 import SimpleTimes.{Point, Vector}
+import SimpleTimes.Digit
 
 final class SimpleTimesTest extends FlatSpec with GeneratorDrivenPropertyChecks with Matchers {
 
@@ -46,26 +47,26 @@ final class SimpleTimesTest extends FlatSpec with GeneratorDrivenPropertyChecks 
   }
 
   "head()/tail()/length()" should "be correct" in {
-    Vector(0).head shouldBe 0
-    Vector(0).tail(0) shouldBe 0
-    Vector(0).tail(1) shouldBe 0
-    Vector(0, 2).head shouldBe 0
-    Vector(0, 2).tail(0) shouldBe 2
-    Vector(0, 2).tail(1) shouldBe 0
+    Vector(0).get(Digit.DAYS) shouldBe 0
+    Vector(0).get(Digit.HOURS) shouldBe 0
+    Vector(0).get(Digit.PARTS) shouldBe 0
+    Vector(0, 2).get(Digit.DAYS) shouldBe 0
+    Vector(0, 2).get(Digit.HOURS) shouldBe 2
+    Vector(0, 2).get(Digit.PARTS) shouldBe 0
 
-    Vector(0).head(3).digits shouldBe Seq(3)
-    Vector(0).tail(0, 2).digits shouldBe Seq(0, 2)
-    Vector(0).tail(1, 3).digits shouldBe Seq(0, 0, 3)
-    Vector(0, 2).head(4).digits shouldBe Seq(4, 2)
-    Vector(0, 2).tail(0, 3).digits shouldBe Seq(0, 3)
-    Vector(0, 2).tail(1, 3).digits shouldBe Seq(0, 2, 3)
+    Vector(0).set(Digit.DAYS, 3).digits shouldBe Seq(3)
+    Vector(0).set(Digit.HOURS, 2).digits shouldBe Seq(0, 2)
+    Vector(0).set(Digit.PARTS, 3).digits shouldBe Seq(0, 0, 3)
+    Vector(0, 2).set(Digit.DAYS, 4).digits shouldBe Seq(4, 2)
+    Vector(0, 2).set(Digit.HOURS, 3).digits shouldBe Seq(0, 3)
+    Vector(0, 2).set(Digit.PARTS, 3).digits shouldBe Seq(0, 2, 3)
 
-    Vector(0).head(3).length shouldBe 0
-    Vector(0).tail(0, 2).length shouldBe 1
-    Vector(0).tail(1, 3).length shouldBe 2
-    Vector(0, 2).head(4).length shouldBe 1
-    Vector(0, 2).tail(0, 3).length shouldBe 1
-    Vector(0, 2).tail(1, 3).length shouldBe 2
+    Vector(0).set(Digit.DAYS, 3).length shouldBe 0
+    Vector(0).set(Digit.HOURS, 2).length shouldBe 1
+    Vector(0).set(Digit.PARTS, 3).length shouldBe 2
+    Vector(0, 2).set(Digit.DAYS, 4).length shouldBe 1
+    Vector(0, 2).set(Digit.HOURS, 3).length shouldBe 1
+    Vector(0, 2).set(Digit.PARTS, 3).length shouldBe 2
   }
 
   "+()" should "be correct" in {
@@ -98,7 +99,7 @@ final class SimpleTimesTest extends FlatSpec with GeneratorDrivenPropertyChecks 
   "fromRational()" should "be correct" in {
     def test(value: Vector): Unit = {
       val rational = value.toRational
-      val number = Vector.fromRational(rational, Times.defaultLength)
+      val number = Vector.fromRational(rational, SimpleTimes.defaultLength)
       number shouldBe value
     }
 
@@ -114,27 +115,27 @@ final class SimpleTimesTest extends FlatSpec with GeneratorDrivenPropertyChecks 
 
   "roundTo()" should "be correct" in {
     Vector(3).roundTo(0) shouldBe Vector(3)
-    Vector(3).roundTo(1) shouldBe Vector(3)
+    Vector(3).roundTo(Digit.HOURS) shouldBe Vector(3)
     Vector(3, 5).roundTo(0) shouldBe Vector(3)
-    Vector(3, 5).roundTo(1) shouldBe Vector(3, 5)
-    Vector(3, 5).roundTo(2) shouldBe Vector(3, 5)
+    Vector(3, 5).roundTo(Digit.HOURS) shouldBe Vector(3, 5)
+    Vector(3, 5).roundTo(Digit.PARTS) shouldBe Vector(3, 5)
     -Vector(3, 5).roundTo(0) shouldBe -Vector(3)
     -Vector(3, 12).roundTo(0) shouldBe -Vector(4)
-    -Vector(3, 5).roundTo(1) shouldBe -Vector(3, 5)
-    -Vector(3, 5).roundTo(2) shouldBe -Vector(3, 5)
+    -Vector(3, 5).roundTo(Digit.HOURS) shouldBe -Vector(3, 5)
+    -Vector(3, 5).roundTo(Digit.PARTS) shouldBe -Vector(3, 5)
     Vector(3, 5, 4).roundTo(0) shouldBe Vector(3)
-    Vector(3, 5, 4).roundTo(1) shouldBe Vector(3, 5)
-    Vector(3, 5, 4).roundTo(2) shouldBe Vector(3, 5, 4)
-    Vector(3, 5, 4).roundTo(3) shouldBe Vector(3, 5, 4)
+    Vector(3, 5, 4).roundTo(Digit.HOURS) shouldBe Vector(3, 5)
+    Vector(3, 5, 4).roundTo(Digit.PARTS) shouldBe Vector(3, 5, 4)
+    Vector(3, 5, 4).roundTo(Digit.MOMENTS) shouldBe Vector(3, 5, 4)
     Vector(-3, 5, 4).roundTo(0) shouldBe Vector(-3)
-    Vector(-3, 5, 4).roundTo(1) shouldBe Vector(-3, 5)
-    Vector(-3, 5, 4).roundTo(2) shouldBe Vector(-3, 5, 4)
-    Vector(-3, 5, 4).roundTo(3) shouldBe Vector(-3, 5, 4)
-    Vector(3, 5, 4, 1).roundTo(2) shouldBe Vector(3, 5, 4)
-    Vector(-3, 5, 4, 1).roundTo(2) shouldBe Vector(-3, 5, 4)
-    Vector(-3, 5, 4, 37).roundTo(2) shouldBe Vector(-3, 5, 4)
-    Vector(-3, 5, 4, 38).roundTo(2) shouldBe Vector(-3, 5, 5)
-    Vector(-3, 5, 4, 39).roundTo(2) shouldBe Vector(-3, 5, 5)
+    Vector(-3, 5, 4).roundTo(Digit.HOURS) shouldBe Vector(-3, 5)
+    Vector(-3, 5, 4).roundTo(Digit.PARTS) shouldBe Vector(-3, 5, 4)
+    Vector(-3, 5, 4).roundTo(Digit.MOMENTS) shouldBe Vector(-3, 5, 4)
+    Vector(3, 5, 4, 1).roundTo(Digit.PARTS) shouldBe Vector(3, 5, 4)
+    Vector(-3, 5, 4, 1).roundTo(Digit.PARTS) shouldBe Vector(-3, 5, 4)
+    Vector(-3, 5, 4, 37).roundTo(Digit.PARTS) shouldBe Vector(-3, 5, 4)
+    Vector(-3, 5, 4, 38).roundTo(Digit.PARTS) shouldBe Vector(-3, 5, 5)
+    Vector(-3, 5, 4, 39).roundTo(Digit.PARTS) shouldBe Vector(-3, 5, 5)
   }
 
   "toString()" should "be correct" in {

--- a/service/src/main/scala/org/podval/calendar/service/Renderer.scala
+++ b/service/src/main/scala/org/podval/calendar/service/Renderer.scala
@@ -335,7 +335,7 @@ object Renderer {
 
       val tkufot: TypedTag[String] = {
         def tkufa(flavor: Season.ForYear, season: Season): String =
-          Calendar.fromJewish(flavor.seasonForYear(season, year)).toLanguageString(spec)
+          flavor.seasonForYear(season, year).toLanguageString(spec)
 
         table(
           tr(td("Tkufa"), td("Shmuel"), td("Rav Ada")),


### PR DESCRIPTION
- made length parameter explicit throughout :)
- made both to[Seconds]LanguageString() available on MomentBase;
- TextTest(s) redone using FunSpec;

Unify position indexes and precisions/lengths for number systems #32 
- use symbolic names for digit positions;
- start tail positions from 1, not 0;
- assign index 0 to the head digit;
- replace head()/tail() with straight use of get()/set();
- get/set/roundTo flavors that take digit descriptor;
- included head sign in signPartial;
- Numbers.toString simplified to not use headSign;
- removed headSign;
- added digit descriptors that have signs;
- cleanup.
resolves #32
