### PR TITLE
- DocBook Gradle plugin requires Gradle 5.5.1;

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,9 +1,9 @@
 steps:
 # gradle: prepare docker context
-# Latest Gradle builder on Google Cloud Build is v4.6; I need v5.0,
+# Latest Gradle builder on Google Cloud Build is v4.6; I need v5.1.1.0,
 # so I am using a custom builder I had to build myself:
 #  - name: 'gcr.io/cloud-builders/gradle'
-  - name: 'gcr.io/calendar-service-1/gradle:5.0-jdk-8'
+  - name: 'gcr.io/calendar-service-1/gradle:5.1.1-jdk-8'
     args: [':service:prepareDockerContext']
 
 # docker: build docker image

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -35,21 +35,27 @@ docbook {
 
 /*
 
-Works:
+Roboto and NotoSans fonts (except for Mono) do not work with FOP;
+  see https://issues.apache.org/jira/browse/FOP-2704 ("coverage set class table not yet supported")
+
+./gradlew :paper:listFonts   lists fonts available to FOP
+
+Work:
   DejaVu Sans, DejaVu Sans Mono, DejaVu Serif
   Liberation Mono, Liberation Sans, Liberation Serif
 
-Doesn't work (at least, without setting the sans.font.family)
+Don't work (at least, without setting the sans.font.family)
   Monserratt, Nimbus Sans, PT Sans, Caladea - no Hebrew.
   Droid Sans, Droid Sans Hebrew, Droid Sans Mono - missing symbols; Hebrew - in superscript position.
 
-Carlito
-Comfortaa
-FreeMono  FreeSans  FreeSerif
-Times, Times Roman
-URW Bookman
-URW Gothic
- */
+Didn't try:
+  Carlito
+  Comfortaa
+  FreeMono  FreeSans  FreeSerif
+  Times, Times Roman
+  URW Bookman
+  URW Gothic
+*/
 
 
   // TODO define entities:


### PR DESCRIPTION
- selecting a font that actually works.