### PR TITLE
- remove chapter numbers (from the text, not yet from the TOC);

### DIFF
--- a/paper/src/main/docBook/glossary.xml
+++ b/paper/src/main/docBook/glossary.xml
@@ -16,7 +16,21 @@
         <glossterm>mean lunar anomaly (אמצע המסלול)</glossterm>
         <acronym>mla</acronym>
         <glossdef>
-          <para>Mean angular coordinate of the Moon on its epicicle.</para>
+          <para>Mean angular coordinate of the Moon on its epicycle.</para>
+        </glossdef>
+      </glossentry>
+
+      <glossentry xml:id="tll-term">
+        <glossterm>true lunar longitude (הירח האמיתי)</glossterm>
+        <glossdef>
+          <para>???</para>
+        </glossdef>
+      </glossentry>
+
+      <glossentry xml:id="dd-term">
+        <glossterm>doubled distance (מרחק הכפול)</glossterm>
+        <glossdef>
+          <para>???</para>
         </glossdef>
       </glossentry>
     </glossdiv>

--- a/paper/src/main/docBook/translation/chapter15.xml
+++ b/paper/src/main/docBook/translation/chapter15.xml
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<section
-  xmlns="http://docbook.org/ns/docbook" version="5.0"
-  xmlns:xi="http://www.w3.org/2001/XInclude"
->
+<section xmlns="http://docbook.org/ns/docbook" version="5.0">
   <title>Chapter 15</title>
 
   <section>
     <title>Law 1</title>
 
     <para>
-      To find true lunar longitude (הירח האמיתי) on a specific day:
+      To find <glossterm linkend="tll-term">true lunar longitude</glossterm> on a specific day:
       First, calculate mean lunar longitude during observation time of the desired night.
       Also, calculate mean lunar anomaly and mean solar longitude for the same time.
       Then, subtract mean solar longitude from the mean lunar longitude and double the result.
-      This value is called <glossterm>doubled distance</glossterm> (מרחק הכפול).
+      This value is called <glossterm linkend="dd-term">doubled distance</glossterm> .
     </para>
   </section>
 

--- a/paper/src/main/xsl/common-custom.xsl
+++ b/paper/src/main/xsl/common-custom.xsl
@@ -8,11 +8,12 @@
   <!-- This is needed (?) for template-tweaking customizations, like removal of "Chapter" in chapter title -->
   <xsl:param name="local.l10n.xml" select="document('')"/>
 
-  <!-- Remove "Chapter" in chapter title -->
+  <!-- Remove number and "Chapter" in chapter title -->
   <l:i18n xmlns:l="http://docbook.sourceforge.net/xmlns/l10n/1.0">
     <l:l10n language="en">
       <l:context name="title-numbered">
-        <l:template name="chapter" text="%n.&#160;%t"/>
+<!--        <l:template name="chapter" text="%n.&#160;%t"/>-->
+        <l:template name="chapter" text="%t"/>
       </l:context>
     </l:l10n>
   </l:i18n>


### PR DESCRIPTION
- mixing English and Hebrew in the text sometimes (!) produces parasitic '-ucluc's in the PDF...
  I am going to segregate Hebrew terms in the Glossary anyways...
resolves #244.